### PR TITLE
fix(AppComponent): initialize name

### DIFF
--- a/src/lib/component/app.component.ts
+++ b/src/lib/component/app.component.ts
@@ -13,5 +13,5 @@ import { Component } from '@angular/core';
   `]
 })
 export class AppComponent {
-  name: 'App';
+  name = 'App';
 }


### PR DESCRIPTION
The *name* property remained uninitialized, which is probably not what was intended. Besides, since 'App' was being used as a type then that was the only allowed value that could be assigned to the property.